### PR TITLE
Adds .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.DS_STORE
+.sass-cache
+node_modules
+build
+npm-debug.log


### PR DESCRIPTION
Adds a separate `.npmignore` file to ensure that `/lib` is gitignored, but *IS* published to NPM. Without this, NPM just follows the `.gitignore` file.